### PR TITLE
A sort of fix to the panel and scroll issue

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -184,6 +184,10 @@ header ul {
 
 @media screen and (min-width: 48em) {
 
+  .scotch-panel-canvas {
+    transform: none !important;
+  }
+
   #panel{
     right: 0 !important;
   }

--- a/js/main.js
+++ b/js/main.js
@@ -1,31 +1,23 @@
-
-
 (function($) {
 
   // var $window = $(window);
 
-  function checkWidth() {
-    var windowSize = $(window).width();
-    if ($(window).width() > 769) {
-      $('.scotch-panel-canvas').removeAttr('style');
-    }
-    // if ($(window).width() <= 769) {
-    //   $('.scotch-panel-canvas').attr('style');
-    // }
-    else {
-      return;
-    }
-  }
+  // function checkWidth() {
+  //   var windowSize = $(window).width();
+  //   if ($(window).width() > 769) {
+  //     $('.scotch-panel-canvas').removeAttr('style');
+  //   }
+  //   else {
+  //     $('.scotch-panel-canvas').attr('style');
+  //   }
+
+  // }
 
   function windowResize() {
     if ($(window).resize) {
       checkWidth();
     }
   }
-  
-  // else {
-  //   $('scotch-panel-canvas').attr('style');
-  // }
   
   // header scroller
   $(window).scroll(function () {
@@ -42,6 +34,7 @@
     $(this).toggleClass('open');
   });
 
+  // off canvas panel
   var panelExample = $('#panel').scotchPanel({
     containerSelector: 'body', // Make this appear on the entire screen
     direction: 'right', // Make it toggle in from the left
@@ -52,7 +45,6 @@
     enableEscapeKey: true // Clicking Esc will close the panel
   });
 
-  // off canvas panel
   // $(window).resize(function() {
   //   if ($(window).width() <= 769) {  
   //     panelExample.close();
@@ -116,8 +108,8 @@
         lightBox.init();
       });
   });
-  checkWidth();
-  windowResize();
+  // checkWidth();
+  // windowResize();
   // $(window).resize(checkWidth());
 })(jQuery);
 


### PR DESCRIPTION
just added !important - it works - to have the transform be none on > 48em view. The js functions I had made would remove the attr, yet when they were re-added on window resize, they'd be missing attributes except the ones that broke down the scroll and panel functionality. There is a better way