### PR TITLE
Edited the pwsp height attr

### DIFF
--- a/css/photoswipe.css
+++ b/css/photoswipe.css
@@ -7,7 +7,7 @@
   display: none;
   position: absolute;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   left: 0;
   top: 0;
   overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@
 
     </div>
 
-    <script src="js/photoswipe-ui-default.min.js"></script>
     <script src="js/photoswipe.min.js"></script>
+    <script src="js/photoswipe-ui-default.min.js"></script>
     <script src="js/scotchPanels.min.js"></script>
     <script src="js/main.js"></script>
   </body>

--- a/js/main.js
+++ b/js/main.js
@@ -101,7 +101,8 @@
         var options = {
           index: $index,
           bgOpacity: 0.7,
-          showHideOpacity: true
+          showHideOpacity: true,
+          modal: false
         }
 
         var lightBox = new PhotoSwipe($pswp, PhotoSwipeUI_Default, items, options);


### PR DESCRIPTION
Changed to 100vh as for whatever reason, pwsp was reading the height as the entire length of the page so once clicked on an image that was say, first, that image would be displayed in the middle of the whole scale of the page rather than centered wherever the viewer was at. It's not perfect as once clicked, the image is centered on your view, while the background jumps back to the top of the page. After closing, the background - which is now your view - goes back to where you had clicked. Works great on desktop. Internet browsing on your phone is shit let's be honest.