### PR TITLE
added a function to check for &nbsp;

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 (function($) {
-  
+
   // header scroller
   $(window).scroll(function () {
     var scroll = $(window).scrollTop()
@@ -14,6 +14,16 @@
   $('#nav-icon').on('click', function() {
     $(this).toggleClass('open');
   });
+
+  // spacing magnifies the out of alignment of the .nav-item on mobile
+  // only checks on window load, so resizing has no part. Only really noticeable if
+  // you cruise your desktop screen < 600 
+  if($(window).width() < 769) {
+    // console.log('small window');
+    $('.nav-item').each(function(){
+      $(this).html($(this).html().replace(/&nbsp;/gi,''));
+    }); 
+  }
 
   // var $twoClasses = $('.nav-name', '.nav-item');
   // $('#nav-name').on('mouseenter', function() {


### PR DESCRIPTION
if the window.width is < 769 the &nbsp; is removed from .nav-links as it ruins the alignment on mobile. Only happens once on load not resizing